### PR TITLE
Fix error when clearing out number inputs

### DIFF
--- a/src/components/forms/NumberField/NumberField.tsx
+++ b/src/components/forms/NumberField/NumberField.tsx
@@ -52,7 +52,7 @@ export const NumberField = ({
           data-augmented-ui={augmented ? "tl-clip border" : undefined}
           className={augmented ? "augmented" : undefined}
           value={value}
-          onChange={(_, valueAsNumber) => onChange(valueAsNumber)}
+          onChange={(_, valueAsNumber) => onChange(valueAsNumber || 0)}
         >
           <NumberInputField
             ref={ref}


### PR DESCRIPTION
### Purpose

When clearing number inputs, the app would throw an error preventing the user from accessing any part of the character sheet where that number was set, due to attempting to parse NaN as a number.

## Changes

- Make number inputs pass 0 for their input value if the field is cleared out.